### PR TITLE
Replace rpc apps call

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -215,9 +215,9 @@
       }
     },
     "@pokt-network/pocket-js": {
-      "version": "0.6.13-rc",
-      "resolved": "https://registry.npmjs.org/@pokt-network/pocket-js/-/pocket-js-0.6.13-rc.tgz",
-      "integrity": "sha512-JpMs6eRrFVRfa0Vkkj7I3kovr6pM39rr+xwZLe9SkUQ32ZdGgEAt1KtzTkOTkbya/EoQdCh0ewW+hx8ZETRNrQ==",
+      "version": "0.6.16-rc",
+      "resolved": "https://registry.npmjs.org/@pokt-network/pocket-js/-/pocket-js-0.6.16-rc.tgz",
+      "integrity": "sha512-kyeK0mKMTU/k17sAduD3WkySk6FzobCVIYESd5opoecz+H/n0CM5e09XG19G4LYfDDUWhjw5aRfINWJevrFH0g==",
       "requires": {
         "@pokt-network/aat-js": "0.1.1-rc",
         "@pokt-network/amino-js": "0.7.5-alpha.1",
@@ -1894,9 +1894,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-safe-stringify": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
-      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fastq": {
       "version": "1.12.0",

--- a/app/package.json
+++ b/app/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@influxdata/influxdb-client": "^1.17.0",
-    "@pokt-network/pocket-js": "^0.6.13-rc",
+    "@pokt-network/pocket-js": "^0.6.16-rc",
     "axios": "^0.21.2",
     "dayjs": "^1.10.6",
     "discord.js": "12.5.3",

--- a/app/src/functions/notify-endpoint-usage/app.ts
+++ b/app/src/functions/notify-endpoint-usage/app.ts
@@ -56,16 +56,15 @@ exports.handler = async () => {
   )
 
   const loadBalancers: Map<string, ILoadBalancer> = convertToMap(
-    await
-      retryEvery(
-        // @ts-ignore
-        getModelFromDBOrCache.bind(
-          null,
-          redis,
-          LoadBalancerModel,
-          'nt-loadBalancers'
-        )
-      ),
+    await retryEvery(
+      // @ts-ignore
+      getModelFromDBOrCache.bind(
+        null,
+        redis,
+        LoadBalancerModel,
+        'nt-loadBalancers'
+      )
+    ),
     '_id'
   )
 

--- a/app/src/functions/send-discord-notification/app.ts
+++ b/app/src/functions/send-discord-notification/app.ts
@@ -57,7 +57,7 @@ function buildEmbedMessages(
   for (const [_, logs] of data) {
     const message: EmbedFieldData[] = []
 
-    // Possibly empty variables have  a default dash as values 
+    // Possibly empty variables have  a default dash as values
     // cannot be an empty string
     if (isApplicationLog(logs[0])) {
       const {
@@ -132,16 +132,15 @@ function buildEmbedMessages(
   return messages
 }
 
-
 async function getMaxUsageMsg(): Promise<EmbedFieldData[]> {
   let dailyMaximum = {
     hour: '',
     apps: 0,
-    lbs: 0
+    lbs: 0,
   }
 
-  const dailyMaxUsage = (
-    await getQueryResults<MaxUsage>('successfully calculated usage')
+  const dailyMaxUsage = await getQueryResults<MaxUsage>(
+    'successfully calculated usage'
   )
 
   for (const currHour of dailyMaxUsage) {
@@ -162,7 +161,8 @@ async function getMaxUsageMsg(): Promise<EmbedFieldData[]> {
   return [
     { name: 'Hour', value: hour, inline: true },
     { name: 'Apps', value: formatNumber(apps), inline: true },
-    { name: 'Lbs', value: formatNumber(lbs), inline: true },]
+    { name: 'Lbs', value: formatNumber(lbs), inline: true },
+  ]
 }
 
 exports.handler = async () => {
@@ -199,7 +199,10 @@ exports.handler = async () => {
   await Promise.allSettled(messagesToSend)
 
   const maxUsage = await getMaxUsageMsg()
-  await sendEmbedMessage('Time of day with maximum number of apps/lbs', maxUsage)
+  await sendEmbedMessage(
+    'Time of day with maximum number of apps/lbs',
+    maxUsage
+  )
 
   return { message: 'ok' }
 }

--- a/app/src/lib/discord.ts
+++ b/app/src/lib/discord.ts
@@ -15,12 +15,11 @@ const EMBED_FIELDS_LIMIT = 25
 
 const client = new Client()
 
-  ; (async function startClient() {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    client.on('ready', function () { })
-    await client.login(DISCORD_TOKEN)
-  })()
-
+;(async function startClient() {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  client.on('ready', function () {})
+  await client.login(DISCORD_TOKEN)
+})()
 
 /**
  * Split embed fields to be lower than the allowed limit by discord
@@ -35,7 +34,7 @@ export function splitEmbeds(fields: EmbedFieldData[]): EmbedFieldData[][] {
   const iterations = Math.ceil(fields.length / EMBED_FIELDS_LIMIT)
 
   for (let i = 0; i < iterations; i++) {
-    const start = i * EMBED_FIELDS_LIMIT;
+    const start = i * EMBED_FIELDS_LIMIT
 
     const maxEnd = start + EMBED_FIELDS_LIMIT
     const end = maxEnd <= fields.length ? maxEnd : fields.length

--- a/app/src/models/types.ts
+++ b/app/src/models/types.ts
@@ -1,6 +1,6 @@
 import { StakingStatus } from '@pokt-network/pocket-js'
 import { INotificationSettings } from './Application'
-import { Types } from 'mongoose';
+import { Types } from 'mongoose'
 
 export type GetUsageDataQuery = {
   relays: number

--- a/app/src/utils/calculations.ts
+++ b/app/src/utils/calculations.ts
@@ -18,9 +18,9 @@ import { getSecondsForNextHour } from '../lib/date-utils'
 // times as we're only interested on the maximum value per hour
 const SECONDS_TO_RELOG = 360 // 6 min
 
-// When caching an app/lb, a small exceedent is needed so the db have time to 
+// When caching an app/lb, a small exceedent is needed so the db have time to
 // reindex the values of the next hour
-const EXCEEDED_TIME = 120 // 2 min 
+const EXCEEDED_TIME = 120 // 2 min
 
 const THRESHOLD_LIMIT = parseInt(process.env.THRESHOLD_LIMIT || '100')
 
@@ -98,7 +98,8 @@ async function logEntityThreshold(
           `nt-lb-${id}`,
           'true',
           'EX',
-          remainingSecondsOnHour + EXCEEDED_TIME)
+          remainingSecondsOnHour + EXCEEDED_TIME
+        )
       }
     }
   }


### PR DESCRIPTION
The pocketjs client is failing on the `getApps` call, this issue is directly from the core call and will be addressed later, meanwhile temporarily replace the pocket js call with a direct rpc call for the apps information